### PR TITLE
Reorganize modules, fix circle drawing

### DIFF
--- a/cairo/src/Slay/Cairo.hs
+++ b/cairo/src/Slay/Cairo.hs
@@ -122,5 +122,5 @@ instance RenderElement g (PrimCurve g) where
 instance RenderElement g (PrimCircle g)   where
   renderElement (PrimCircle cc c) getG (Offset x y) = do
       setSourceColor $ getG cc
-      Cairo.arc (toSigned c + x) (toSigned c + y) (toSigned c) 0 180
+      Cairo.arc (toSigned c + x) (toSigned c + y) (toSigned c) 0 (2 * pi)
       Cairo.fill

--- a/core/slay-core.cabal
+++ b/core/slay-core.cabal
@@ -1,65 +1,12 @@
-name:
-  slay-core
-
-version:
-  0
-
-build-type:
-  Simple
-
-cabal-version:
-  >=2.0
+name: slay-core
+version: 0
+build-type: Simple
+cabal-version: >=2.1
 
 library
-
-  signatures:
-    Slay.Number
-
-  exposed-modules:
-    Slay.Core
-
-  build-depends:
-    base,
-    reflection
-
-  hs-source-dirs:
-    src
-
-  default-language:
-    Haskell2010
-
-  default-extensions:
-    BangPatterns
-    ConstraintKinds
-    DataKinds
-    DefaultSignatures
-    DeriveGeneric
-    DeriveFunctor
-    DeriveFoldable
-    DeriveTraversable
-    FlexibleContexts
-    FlexibleInstances
-    GADTs
-    GeneralizedNewtypeDeriving
-    LambdaCase
-    MultiParamTypeClasses
-    MultiWayIf
-    NegativeLiterals
-    OverloadedStrings
-    PatternSynonyms
-    PolyKinds
-    RankNTypes
-    RecordWildCards
-    RecursiveDo
-    ScopedTypeVariables
-    StandaloneDeriving
-    TemplateHaskell
-    TupleSections
-    TypeApplications
-    TypeFamilies
-    TypeOperators
-    UndecidableInstances
-    ViewPatterns
-
-  ghc-options:
-    -Wall
+  signatures: Slay.Number
+  exposed-modules: Slay.Core
+  build-depends: base
+  hs-source-dirs: src
+  default-language: Haskell2010
+  ghc-options: -Wall -fno-warn-partial-type-signatures

--- a/gtk/slay-gtk.cabal
+++ b/gtk/slay-gtk.cabal
@@ -14,6 +14,10 @@ library
 
   exposed-modules:
     Slay.Gtk
+    Slay.Gtk.Phaser
+    Slay.Gtk.PreMatrix
+    Slay.Gtk.KeyCode
+    Slay.Gtk.Util
 
   build-depends:
     base,
@@ -23,6 +27,7 @@ library
     transformers,
     text,
     microlens-platform,
+    template-haskell,
     slay-cairo
 
   hs-source-dirs:
@@ -67,7 +72,6 @@ library
   ghc-options:
     -Wall
     -Wno-missing-pattern-synonym-signatures
-    -threaded
 
 executable slay-gtk-example
   main-is:

--- a/gtk/src/Slay/Gtk/KeyCode.hs
+++ b/gtk/src/Slay/Gtk/KeyCode.hs
@@ -1,0 +1,23 @@
+module Slay.Gtk.KeyCode where
+
+import Data.Char as Char
+import Data.Text as Text
+import Data.Word
+
+import Graphics.UI.Gtk.Gdk.Keys (keyName)
+import qualified Language.Haskell.TH as TH
+
+return $
+  let
+    mkDecs1 i name =
+      [ TH.PatSynSigD name (TH.ConT ''Word32),
+        TH.PatSynD name (TH.PrefixPatSyn[]) TH.ImplBidir (TH.LitP (TH.IntegerL (toInteger i))) ]
+    mkDecs i = if valid then mkDecs1 i name else []
+      where
+        name = TH.mkName (Text.unpack nameStr)
+        nameStr = mappend "K_" key
+        firstc = Text.head key
+        valid = not (Text.null key) && Char.isLetter firstc
+        key = keyName i
+  in
+    [0..2^(16::Int)] >>= mkDecs

--- a/gtk/src/Slay/Gtk/Phaser.hs
+++ b/gtk/src/Slay/Gtk/Phaser.hs
@@ -1,0 +1,24 @@
+module Slay.Gtk.Phaser
+  ( Phaser(..),
+    createPhaser,
+    resetPhaser,
+    updatePhaser,
+    readPhaser
+  ) where
+
+import Data.IORef
+
+newtype Phaser = Phaser (IORef Word)
+
+createPhaser :: IO Phaser
+createPhaser = Phaser <$> newIORef 0
+
+resetPhaser :: Phaser -> IO ()
+resetPhaser (Phaser r) = writeIORef r 0
+
+updatePhaser :: Phaser -> IO ()
+updatePhaser (Phaser r) = atomicModifyIORef' r (\x -> (x + 1, ()))
+
+readPhaser :: Phaser -> (Word -> r) -> IO r
+readPhaser (Phaser r) cont = cont <$> readIORef r
+

--- a/gtk/src/Slay/Gtk/PreMatrix.hs
+++ b/gtk/src/Slay/Gtk/PreMatrix.hs
@@ -1,0 +1,50 @@
+module Slay.Gtk.PreMatrix
+  ( PreMatrix(..),
+    pmScaleL,
+    pmRotateL,
+    pmOffsetL,
+    CachedPreMatrix(..),
+    cachedPreMatrix
+  ) where
+
+import Data.Fixed
+import Lens.Micro.Platform
+
+import qualified Graphics.Rendering.Cairo.Matrix as Matrix
+import qualified Graphics.Rendering.Cairo as Cairo
+
+import Slay.Gtk.Util
+
+data PreMatrix = PreMatrix
+  { pmScale :: Centi,
+    pmRotate :: Integer, -- 1/12
+    pmOffset :: (Integer, Integer)
+  }
+
+makeLensesWith postfixLFields ''PreMatrix
+
+data CachedPreMatrix = CachedPreMatrix
+  { cpmPreMatrix :: PreMatrix,
+    cpmMatrix1 :: Cairo.Matrix, -- cached result of preMatrix1 (no offset)
+    cpmMatrix2 :: Cairo.Matrix  -- cached result of preMatrix2 (with offset)
+  }
+
+cachedPreMatrix :: PreMatrix -> CachedPreMatrix
+cachedPreMatrix preMatrix = CachedPreMatrix
+  { cpmPreMatrix = preMatrix,
+    cpmMatrix1 = matrix1,
+    cpmMatrix2 = matrix2
+  }
+  where
+    matrix1 = prepareMatrix1 preMatrix
+    matrix2 = prepareMatrix2 preMatrix matrix1
+
+prepareMatrix1 :: PreMatrix -> Cairo.Matrix
+prepareMatrix1 PreMatrix{..} =
+  Matrix.rotate (pi * realToFrac pmRotate / 12) $
+  Matrix.scale (realToFrac pmScale) (realToFrac pmScale) $
+  Matrix.identity
+
+prepareMatrix2 :: PreMatrix -> Cairo.Matrix -> Cairo.Matrix
+prepareMatrix2 PreMatrix{..} =
+  Matrix.translate (realToFrac $ fst pmOffset) (realToFrac $ snd pmOffset)

--- a/gtk/src/Slay/Gtk/Util.hs
+++ b/gtk/src/Slay/Gtk/Util.hs
@@ -1,0 +1,48 @@
+module Slay.Gtk.Util
+  ( postfixLFields,
+    getExcess,
+    boundingBox,
+    snap,
+    snapExtents,
+    setBackground
+  ) where
+
+import Data.Semigroup
+import Data.List.NonEmpty as NonEmpty
+import Language.Haskell.TH.Syntax
+import Lens.Micro.Platform
+
+import qualified Graphics.Rendering.Cairo as Cairo
+
+import Slay.Cairo
+
+postfixLFields :: LensRules
+postfixLFields = lensRules & lensField .~ appendSuffixL
+  where appendSuffixL _ _ s = [TopName . mkName $ nameBase s ++ "L"]
+
+getExcess :: Double -> Double -> Double
+getExcess vacant actual = max 0 (vacant - actual)
+
+boundingBox :: Ord a => NonEmpty (a, a) -> (a, a, a, a)
+boundingBox xs = (l,r,t,b)
+  where
+    ((Min l, Min t), (Max r, Max b)) =
+      sconcat $ (\(x, y) -> ((Min x, Min y), (Max x, Max y))) <$> xs
+
+snap :: Double -> Double
+snap = fromInteger . ceiling
+
+snap' :: Unsigned -> Unsigned
+snap' = unsafeToUnsigned . snap . toSigned
+
+snapExtents :: Extents -> Extents
+snapExtents (Extents w h) = Extents (snap' w) (snap' h)
+
+setBackground :: Color -> Cairo.Render (Double, Double)
+setBackground background = do
+  (x1, y1, x2, y2) <- Cairo.clipExtents
+  let viewport@(w, h) = (x2 - x1, y2 - y1)
+  viewport <$ do
+    Cairo.rectangle 0 0 w h
+    setSourceColor background
+    Cairo.fill


### PR DESCRIPTION
1. Fix circle drawing (cc @v0d1ch — `Cairo.arc` takes radians, not degrees, so `180` instead of `2 * pi` meant that the circle was drawn 28 times over). Closes #16 
2. Drop the dependency on `reflection` (implement inline).
3. Add a `runLayout` combinator.
4. Refactor the GTK example: move `Phaser` to its own module, auto-generate keycode patterns with TH, add transformation matrix caching.