### PR TITLE
CollageRep without reflection parameter

### DIFF
--- a/cairo/src/Slay/Cairo/Inj.hs
+++ b/cairo/src/Slay/Cairo/Inj.hs
@@ -13,6 +13,6 @@ instance Inj a a where
 instance Inj p a => Inj p (Maybe a) where
   inj = Just . inj
 
-instance (HasView s e a, Inj p e) => Inj p (Collage s a) where
+instance (s -/ e, Inj p e) => Inj p (Collage s) where
   inj = collageSingleton . inj
 

--- a/cairo/src/Slay/Cairo/Prim.hs
+++ b/cairo/src/Slay/Cairo/Prim.hs
@@ -29,11 +29,11 @@ data LRTB a = LRTB
   } deriving (Eq, Ord, Show)
 
 substrate ::
-  HasView s e a =>
+  s -/ e =>
   LRTB Unsigned ->
   (Extents -> e) ->
-  Collage s a ->
-  Collage s a
+  Collage s ->
+  Collage s
 substrate pad mkObject collage =
   collageCompose
     Offset


### PR DESCRIPTION
* The `HasView` constraint now has a synonym `-/`
* The `Collage s a` type is now just `Collage s` (one type parameter less, yay!)
* Make `Layout Identity` unnecessary with `collageElements`.
* Remove CPS in `Layout`.
* Documentation improvements.